### PR TITLE
Get Building on Blazar

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,26 @@
+buildpack:
+  host: git.hubteam.com
+  organization: HubSpotProtected
+  repository: Blazar-Buildpack-Java
+  branch: v2-prebuilt
+
+stepActivation:
+  uploadAndNotify:
+    branches: ['hubspot-release']
+
+steps:
+  - description: "Test across all supported Scala Versions"
+    commands:
+      - echo "SBT_OPTS='-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M' +test"
+      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" +test
+
+  - description: "Package Jar"
+    commands:
+      - echo "sbt package"
+      - sbt package
+
+  - name: uploadAndNotify
+      description: "Notifying deploy service"
+      activeByDefault: false
+      commands:
+        - command: publish-build-success --project

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,7 +6,7 @@ buildpack:
 
 stepActivation:
   uploadAndNotify:
-    branches: ['hubspot-release']
+    branches: ['hubspot']
 
 steps:
   - description: "Test across all supported Scala Versions"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,8 +10,7 @@ buildpack:
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
   PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
-  SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
-  SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
+  SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
   HOME_BIN: "$HOME/bin"
@@ -42,7 +41,7 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
-      - export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version')
+      - echo export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version') >> $BUILD_COMMAND_RC_FILE
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,4 +1,5 @@
-MAVEN_OPTS: -Xmx1024m -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+buildResources:
+  memoryMb: 4096
 
 buildpack:
   host: git.hubteam.com
@@ -7,6 +8,9 @@ buildpack:
   branch: v2-prebuilt
 
 env:
+  PROJECT_NAME: "mbknor-jackson-jsonschema"
+  PROJECT_VERSION: "1.0-hubspot-SNAPSHOT" # this should match what's in version.sbt
+  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
   SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
   SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
@@ -18,7 +22,7 @@ stepActivation:
   uploadAndNotify:
     branches: ['hubspot']
 
-steps:
+before:
   - description: "Download and install sbt"
     commands:
       - mkdir -p /tmp/sbt-install
@@ -31,11 +35,26 @@ steps:
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - $SBT_BIN/sbt +test
+      - $SBT_BIN/sbt test #todo: change to +test
 
-  - description: "Package Jar"
+  - description: "Package + Publish Local"
     commands:
-      - $SBT_BIN/sbt package
+      - $SBT_BIN/sbt publish
+
+  - description: "Move artifacts to upload directory"
+    commands:
+      - ls -al target/com/kjetland/mbknor-jackson-jsonschema_2.12/"$PROJECT_VERSION"
+      - ls -al target/scala-2.12
+      - mkdir $PUBLISH_DIR
+      - ls -al
+      - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
+      - ls -al
+      - ls -al $PUBLISH_DIR #testing: confirm files copied
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml #todo: change the branch
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
+      - ls -al $PUBLISH_DIR #testing: confirm success
 
   - name: uploadAndNotify
     description: "Notifying deploy service"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -35,7 +35,7 @@ before:
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - $SBT_BIN/sbt test #todo: change to +test
+      - $SBT_BIN/sbt +test
 
   - description: "Package + Publish Local"
     commands:
@@ -43,18 +43,12 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
-      - ls -al target/com/kjetland/mbknor-jackson-jsonschema_2.12/"$PROJECT_VERSION"
-      - ls -al target/scala-2.12
       - mkdir $PUBLISH_DIR
-      - ls -al
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
-      - ls -al
-      - ls -al $PUBLISH_DIR #testing: confirm files copied
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml #todo: change the branch
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
-      - ls -al $PUBLISH_DIR #testing: confirm success
 
   - name: uploadAndNotify
     description: "Notifying deploy service"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,6 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PROJECT_VERSION: "1.0-hubspot-SNAPSHOT" # this should match what's in version.sbt
   PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
   SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
   SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
@@ -43,6 +42,7 @@ before:
 
   - description: "Move artifacts to upload directory"
     commands:
+      - export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version')
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -4,23 +4,39 @@ buildpack:
   repository: Blazar-Buildpack-Java
   branch: v2-prebuilt
 
+env:
+  SCALA_VERSION: "1.2.3"  # this should match what's in project/build.properties
+  SBT_TAR_FILE_NAME: "sbt-$SCALA_VERSION.tgz"
+  SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
+  SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
+  HOME_BIN: "$HOME/bin"
+  SBT_BIN: "$HOME_BIN/sbt/bin"
+
 stepActivation:
   uploadAndNotify:
     branches: ['hubspot']
 
 steps:
+  - description: "Download and install sbt"
+    commands:
+      - mkdir -p /tmp/sbt-install
+      - mkdir -p $HOME_BIN
+      - wget --quiet $SBT_TAR_LINK -O $SBT_FILE
+      - tar -xvzf $SBT_FILE -C $HOME_BIN
+      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
+      - chmod u+x $SBT_BIN/sbt
+      - rm -rf /tmp/sbt-install
+
   - description: "Test across all supported Scala Versions"
     commands:
-      - echo "SBT_OPTS='-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M' +test"
-      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" +test
+      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" $SBT_BIN/sbt +test
 
   - description: "Package Jar"
     commands:
-      - echo "sbt package"
-      - sbt package
+      - $SBT_BIN/sbt package
 
   - name: uploadAndNotify
-      description: "Notifying deploy service"
-      activeByDefault: false
-      commands:
-        - command: publish-build-success --project
+    description: "Notifying deploy service"
+    activeByDefault: false
+    commands:
+      - command: publish-build-success --project

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,3 +1,5 @@
+MAVEN_OPTS: -Xmx1024m -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+
 buildpack:
   host: git.hubteam.com
   organization: HubSpotProtected
@@ -23,13 +25,13 @@ steps:
       - mkdir -p $HOME_BIN
       - wget --quiet $SBT_TAR_LINK -O $SBT_FILE
       - tar -xvzf $SBT_FILE -C $HOME_BIN
-      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
+      - printf '#!/bin/bash \nSBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M -XX:+CMSClassUnloadingEnabled" \njava $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"' > $SBT_BIN/sbt
       - chmod u+x $SBT_BIN/sbt
       - rm -rf /tmp/sbt-install
 
   - description: "Test across all supported Scala Versions"
     commands:
-      - SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" $SBT_BIN/sbt +test
+      - $SBT_BIN/sbt +test
 
   - description: "Package Jar"
     commands:

--- a/.hubspot-blazar-discovery.yaml
+++ b/.hubspot-blazar-discovery.yaml
@@ -1,0 +1,1 @@
+disabledDiscoveries: ["maven"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 Jackson jsonSchema Generator (Fork)
 ===================================
-[![Build Status](https://travis-ci.org/zrrobbins/mbknor-jackson-jsonSchema.svg?branch=master)](https://travis-ci.org/zrrobbins/mbknor-jackson-jsonSchema)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.zrrobbins/mbknor-jackson-jsonschema_2.12/badge.svg)](https://search.maven.org/search?q=mbknor-jackson-jsonschema%20com.github.zrrobbins)
 
 Forked from https://github.com/mbknor/mbknor-jackson-jsonSchema, head there for more info. This is a slightly modified version to fit some niche use cases.

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,18 @@
 lazy val commonSettings = Seq(
-  organization := "com.hubspot",
+  organization := "com.kjetland",
+  organizationName := "mbknor",
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  homepage := Some(url("https://github.com/hubspot/mbknor-jackson-jsonSchema")),
-  licenses := Seq("MIT" -> url("https://github.com/hubspot/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
+  homepage := Some(url("https://github.com/mbknor/mbknor-jackson-jsonSchema")),
+  licenses := Seq("MIT" -> url("https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/hubspot/mbknor-jackson-jsonSchema"),
-      "scm:git@github.com:hubspot/mbknor-jackson-jsonSchema.git"
+      url("https://github.com/mbknor/mbknor-jackson-jsonSchema"),
+      "scm:git@github.com:mbknor/mbknor-jackson-jsonSchema.git"
     )
   ),
   developers := List(

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
+  publishTo := Some(Resolver.file("file",  new File("target"))),
   homepage := Some(url("https://github.com/mbknor/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),

--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,17 @@
-import ReleaseTransformations._
-import sbtrelease.ReleasePlugin.autoImport.releaseStepCommand
-
 lazy val commonSettings = Seq(
-  organization := "com.github.zrrobbins",
+  organization := "com.hubspot",
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  useGpg := true,
-  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
-  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
-  homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
-  licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
+  homepage := Some(url("https://github.com/hubspot/mbknor-jackson-jsonSchema")),
+  licenses := Seq("MIT" -> url("https://github.com/hubspot/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),
   startYear := Some(2016),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema"),
-      "scm:git@github.com:zrrobbins/mbknor-jackson-jsonSchema.git"
+      url("https://github.com/hubspot/mbknor-jackson-jsonSchema"),
+      "scm:git@github.com:hubspot/mbknor-jackson-jsonSchema.git"
     )
   ),
   developers := List(
@@ -38,8 +25,6 @@ lazy val commonSettings = Seq(
   compileOrder in Test := CompileOrder.Mixed,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
-  releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   scalacOptions in(Compile, doc) ++= Seq(scalaVersion.value).flatMap {
     case v if v.startsWith("2.12") =>
       Seq("-no-java-comments") //workaround for scala/scala-dev#249
@@ -74,18 +59,3 @@ lazy val root = (project in file("."))
   .settings(name := "mbknor-jackson-jsonSchema")
   .settings(commonSettings: _*)
   .settings(libraryDependencies ++= (deps))
-
-
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  publishArtifacts,
-  setNextVersion,
-  commitNextVersion,
-  pushChanges,
-  releaseStepCommand("sonatypeRelease")
-)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,0 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.35"
+version in ThisBuild := "1.0-hubspot-SNAPSHOT"


### PR DESCRIPTION
### Summary
- Removes "release" related options from .sbt file, since blazar handles artifact publishing
- Remove Travis config
- Adds Blazar prebuilt buildpack and adds steps to execute sbt build (test + package)
- ~Renames packages from `com.kjetland` to `com.hubspot` and project from `mbknor-jackson-jsonSchema` to `jackson-jsonSchema`~

`sbt test` runs successfully here, so now it's just a matter of getting things working inside blazar

@jhaber @stevegutz