### PR TITLE
Update from upstream

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,7 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.0'
+  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.1'
   SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,7 +9,7 @@ buildpack:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PUBLISH_DIR: '"$PROJECT_NAME"_2.12-1.1'
+  PUBLISH_DIR_WITHOUT_VERSION: '"$PROJECT_NAME"_2.12'
   SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
   SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
@@ -42,6 +42,7 @@ before:
   - description: "Move artifacts to upload directory"
     commands:
       - echo export PROJECT_VERSION=$($SBT_BIN/sbt -warn 'print version') >> $BUILD_COMMAND_RC_FILE
+      - echo export PUBLISH_DIR=$PUBLISH_DIR_WITHOUT_VERSION-$(echo $PROJECT_VERSION | sed -n 's/^\([[:digit:]]*\.[[:digit:]]*\)-.*$/\1/p') >> $BUILD_COMMAND_RC_FILE
       - mkdir $PUBLISH_DIR
       - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
       - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ scala:
    - 2.11.8
    - 2.12.0
 
+dist: trusty
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: scala
-scala:
-   - 2.10.4
-   - 2.11.8
-   - 2.12.0
-
-dist: trusty
-jdk:
-- oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  // publishTo := {
-  //   val nexus = "https://oss.sonatype.org/"
-  //   if (isSnapshot.value)
-  //     Some("snapshots" at nexus + "content/repositories/snapshots")
-  //   else
-  //     Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  // },
+  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-//  publishTo := {
-//    val nexus = "https://oss.sonatype.org/"
-//    if (isSnapshot.value)
-//      Some("snapshots" at nexus + "content/repositories/snapshots")
-//    else
-//      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-//  },
+  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
+  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+//  publishTo := {
+//    val nexus = "https://oss.sonatype.org/"
+//    if (isSnapshot.value)
+//      Some("snapshots" at nexus + "content/repositories/snapshots")
+//    else
+//      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+//  },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   useGpg := true,
-  //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
+  publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), // For local testing
+  // publishTo := {
+  //   val nexus = "https://oss.sonatype.org/"
+  //   if (isSnapshot.value)
+  //     Some("snapshots" at nexus + "content/repositories/snapshots")
+  //   else
+  //     Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  // },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials_sonatype"),
   homepage := Some(url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema")),
   licenses := Seq("MIT" -> url("https://github.com/zrrobbins/mbknor-jackson-jsonSchema/blob/master/LICENSE.txt")),

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -377,10 +377,10 @@ class JsonSchemaGenerator
 
     def getDefinitionName (t:JavaType):String = {
       var definitionName = getTypeName(t)
-      t.getBindings.getTypeParameters.forEach(binding => {
-        println(definitionName)
-        definitionName += getDefinitionName(binding)
-      })
+
+      t.getBindings.getTypeParameters.asScala
+        .foreach(definitionName += getDefinitionName(_))
+
       definitionName
     }
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -699,6 +699,10 @@ class JsonSchemaGenerator
           }
       }
 
+      // Set format for java Longs to int64
+      if (_type.getRawClass.getName.equals(classOf[java.lang.Long].getName)) {
+        setFormat(node, "int64")
+      }
 
       new JsonIntegerFormatVisitor with EnumSupport {
         val _node = node

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -311,7 +311,7 @@ class JsonSchemaGenerator
   // failing tests. If we ever decide to contribute back to open source, we will need to add the Java API option.
   var globalRefTracker: Map[JavaType, String] = Map[JavaType, String]()
 
-  // Same as property above, but tracks all found models. This way, if we've seen a model before, we don't need to regenerate it, but can still include
+  // Similar to property above, but tracks all found models. This way, if we've seen a model before, we don't need to regenerate it, but can still include
   // it the "definitions" section of a model that has a ref to it.
   var globalDefinitionsTracker: Map[String, JsonNode] = Map[String, JsonNode]()
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -229,8 +229,9 @@ trait SchemaExtension {
     * This is currently only called on String properties!
     * @param node - the schema of the property
     * @param clazz - the class of the property
+    * @param beanProperty - the bean property
     */
-  def modifyProperty(node:ObjectNode, clazz:Class[_]):Unit
+  def modifyProperty(node:ObjectNode, clazz:Class[_], beanProperty:Optional[BeanProperty]):Unit
 
   /**
     * Given a model's schema node and the class of the model, modify the schema node.
@@ -241,7 +242,7 @@ trait SchemaExtension {
 }
 
 class DefaultSchemaExtension extends SchemaExtension {
-  override def modifyProperty(node: ObjectNode, clazz: Class[_]): Unit = {}
+  override def modifyProperty(node: ObjectNode, clazz: Class[_], beanProperty: Optional[BeanProperty]): Unit = {}
   override def modifyModel(node: ObjectNode, clazz: Class[_]): Unit = {}
 }
 
@@ -551,7 +552,7 @@ class JsonSchemaGenerator
       }
 
       if (_type != null) {
-        config.schemaExtension.modifyProperty(node, _type.getRawClass)
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
       }
 
       new JsonStringFormatVisitor with EnumSupport {
@@ -595,6 +596,9 @@ class JsonSchemaGenerator
           }
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
 
       val itemsNode = JsonNodeFactory.instance.objectNode()
       node.set("items", itemsNode)
@@ -654,6 +658,10 @@ class JsonSchemaGenerator
           }
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
+
       new JsonNumberFormatVisitor  with EnumSupport {
         val _node = node
         override def numberType(_type: NumberType): Unit = l(s"JsonNumberFormatVisitor.numberType: ${_type}")
@@ -704,6 +712,10 @@ class JsonSchemaGenerator
         setFormat(node, "int64")
       }
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
+
       new JsonIntegerFormatVisitor with EnumSupport {
         val _node = node
         override def numberType(_type: NumberType): Unit = l(s"JsonIntegerFormatVisitor.numberType: ${_type}")
@@ -732,6 +744,10 @@ class JsonSchemaGenerator
             defaultValue =>
               node.put("default", defaultValue.value().toBoolean)
           }
+      }
+
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
       }
 
       new JsonBooleanFormatVisitor with EnumSupport {
@@ -769,6 +785,9 @@ class JsonSchemaGenerator
       objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.getContentType), childVisitor)
       definitionsHandler.popworkInProgress()
 
+      if (_type != null) {
+        config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
+      }
 
       new JsonMapFormatVisitor with MySerializerProvider {
         override def keyFormat(handler: JsonFormatVisitable, keyType: JavaType): Unit = {
@@ -1038,6 +1057,10 @@ class JsonSchemaGenerator
                   thisObjectNode.set("options", objectOptionsNode)
                 }
 
+            }
+
+            if (_type != null) {
+              config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))
             }
 
             Some(new JsonObjectFormatVisitor with MySerializerProvider {

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1225,6 +1225,9 @@ class JsonSchemaGenerator
                   a =>
                     injectFromJsonSchemaInject(a, thisPropertyNode.meta)
                 }
+
+                // This is only passing in the meta portion of the property node to be modified!
+                config.schemaExtension.modifyProperty(thisPropertyNode.meta, _type.getRawClass, Optional.ofNullable(prop.orNull))
               }
 
               override def optionalProperty(prop: BeanProperty): Unit = {

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -306,7 +306,7 @@ class JsonSchemaGenerator
   // Whether or not to persist seen models between calls to `generateJsonSchema`. Currently, this is default true when object is constructed from Java, false from scala.
   // This is totally not a good way to do things, but it means I don't need to update HSMP to be backwards compatible with a constructor change here, nor fix a ton of
   // failing tests. If we ever decide to contribute back to open source, we will need to add the Java API option.
-  var globalRefTracker: Map[Class[_], String] = Map[Class[_], String]()
+  var globalRefTracker: Map[JavaType, String] = Map[JavaType, String]()
 
   val dateFormatMapping = Map[String,String](
     // Java7 dates
@@ -349,8 +349,8 @@ class JsonSchemaGenerator
   case class DefinitionInfo(ref:Option[String], jsonObjectFormatVisitor: Option[JsonObjectFormatVisitor])
 
   // Class that manages creating new definitions or getting $refs to existing definitions
-  class DefinitionsHandler(refTracker:Option[Map[Class[_], String]]) {
-    private var class2Ref = if (refTracker.isDefined) refTracker.get else Map[Class[_], String]()
+  class DefinitionsHandler(refTracker:Option[Map[JavaType, String]]) {
+    private var class2Ref = if (refTracker.isDefined) refTracker.get else Map[JavaType, String]()
     private var modelsCreated = false
     private val definitionsNode = JsonNodeFactory.instance.objectNode()
 
@@ -373,10 +373,19 @@ class JsonSchemaGenerator
     }
 
 
-    def getDefinitionName (clazz:Class[_]) = { if (config.useTypeIdForDefinitionName) clazz.getName else clazz.getSimpleName }
+    def getTypeName (t:JavaType) = { if (config.useTypeIdForDefinitionName) t.getRawClass.getName else t.getRawClass.getSimpleName }
+
+    def getDefinitionName (t:JavaType):String = {
+      var definitionName = getTypeName(t)
+      t.getBindings.getTypeParameters.forEach(binding => {
+        println(definitionName)
+        definitionName += getDefinitionName(binding)
+      })
+      definitionName
+    }
 
     // Either creates new definitions or return $ref to existing one
-    def getOrCreateDefinition(clazz:Class[_])(objectDefinitionBuilder:(ObjectNode) => Option[JsonObjectFormatVisitor]):DefinitionInfo = {
+    def getOrCreateDefinition(clazz:JavaType)(objectDefinitionBuilder:(ObjectNode) => Option[JsonObjectFormatVisitor]):DefinitionInfo = {
 
       class2Ref.get(clazz) match {
         case Some(ref) =>
@@ -387,7 +396,7 @@ class JsonSchemaGenerator
 
             case Some(w) =>
               // this is a recursive polymorphism call
-              if ( clazz != w.classInProgress) throw new Exception(s"Wrong class - working on ${w.classInProgress} - got $clazz")
+              if ( clazz.getRawClass != w.classInProgress) throw new Exception(s"Wrong class - working on ${w.classInProgress} - got $clazz")
 
               DefinitionInfo(None, objectDefinitionBuilder(w.nodeInProgress))
           }
@@ -400,8 +409,8 @@ class JsonSchemaGenerator
           var longRef = "#/definitions/" + shortRef
           while( class2Ref.values.toList.contains(longRef)) {
             retryCount = retryCount + 1
-            shortRef = clazz.getSimpleName + "_" + retryCount
-            longRef = "#/definitions/"+clazz.getSimpleName + "_" + retryCount
+            shortRef = getDefinitionName(clazz) + "_" + retryCount
+            longRef = "#/definitions/"+getDefinitionName(clazz) + "_" + retryCount
           }
           class2Ref = class2Ref + (clazz -> longRef)
           modelsCreated = true
@@ -410,13 +419,13 @@ class JsonSchemaGenerator
           val node = JsonNodeFactory.instance.objectNode()
 
           // When processing polymorphism, we might get multiple recursive calls to getOrCreateDefinition - this is a wau to combine them
-          workInProgress = Some(WorkInProgress(clazz, node))
+          workInProgress = Some(WorkInProgress(clazz.getRawClass, node))
 
           definitionsNode.set(shortRef, node)
 
           val jsonObjectFormatVisitor = objectDefinitionBuilder.apply(node)
 
-          config.schemaExtension.modifyModel(node, clazz)
+          config.schemaExtension.modifyModel(node, clazz.getRawClass)
 
           workInProgress = None
 
@@ -428,7 +437,7 @@ class JsonSchemaGenerator
       if (!modelsCreated) None else Some(definitionsNode)
     }
 
-    def getFinalClass2Ref():Map[Class[_], String] = {
+    def getFinalClass2Ref():Map[JavaType, String] = {
       class2Ref
     }
   }
@@ -896,7 +905,7 @@ class JsonSchemaGenerator
           subType: Class[_] =>
             l(s"polymorphism - subType: $subType")
 
-            val definitionInfo: DefinitionInfo = definitionsHandler.getOrCreateDefinition(subType){
+            val definitionInfo: DefinitionInfo = definitionsHandler.getOrCreateDefinition(rootObjectMapper.constructType(subType)){
               objectNode =>
 
                 val childVisitor = createChild(objectNode, currentProperty = None)
@@ -1208,7 +1217,7 @@ class JsonSchemaGenerator
           // This is the first level - we must not use definitions
           objectBuilder(node).orNull
         } else {
-          val definitionInfo: DefinitionInfo = definitionsHandler.getOrCreateDefinition(_type.getRawClass)(objectBuilder)
+          val definitionInfo: DefinitionInfo = definitionsHandler.getOrCreateDefinition(_type)(objectBuilder)
 
           definitionInfo.ref.foreach {
             r =>
@@ -1404,12 +1413,12 @@ class JsonSchemaGenerator
 
   def clearSavedDefinitions(): Unit = {
     // Clear saved definitions
-    globalRefTracker = Map[Class[_], String]()
+    globalRefTracker = Map[JavaType, String]()
   }
 
   // Another janky workaround for HSMP. The JsonSchemaGenerator recursively resolves all submodels and returns a nested JsonNode. However, this loses all the class/type
   // information. We need to know the Java type of all models encountered here in the HSMP, thus have this method to do so.
-  def getSavedDefinitions: util.Map[Class[_], String] = {
+  def getSavedDefinitions: util.Map[JavaType, String] = {
     globalRefTracker.asJava
   }
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -118,7 +118,8 @@ object JsonSchemaConfig {
               uniqueItemClasses:java.util.Set[Class[_]],
               classTypeReMapping:java.util.Map[Class[_], Class[_]],
               jsonSuppliers:java.util.Map[String, Supplier[JsonNode]],
-              persistModels:Boolean
+              persistModels:Boolean,
+              alwaysReturnDefinitions:Boolean
             ):JsonSchemaConfig = {
 
     import scala.collection.JavaConverters._
@@ -138,7 +139,8 @@ object JsonSchemaConfig {
       uniqueItemClasses.asScala.toSet,
       classTypeReMapping.asScala.toMap,
       jsonSuppliers.asScala.toMap,
-      persistModels
+      persistModels,
+      alwaysReturnDefinitions
     )
   }
 
@@ -260,6 +262,7 @@ case class JsonSchemaConfig
   classTypeReMapping:Map[Class[_], Class[_]], // Can be used to prevent rendering using polymorphism for specific classes.
   jsonSuppliers:Map[String, Supplier[JsonNode]], // Suppliers in this map can be accessed using @JsonSchemaInject(jsonSupplierViaLookup = "lookupKey")
   persistModels:Boolean = false, // Whether or not to persist seen models between calls to `generateJsonSchema`
+  alwaysReturnDefinitions:Boolean = false, // If true, will always return corresponding "definitions" if any model properties are ref properties
   subclassesResolver:SubclassesResolver = new SubclassesResolverImpl(), // Using default impl that scans entire classpath
   schemaExtension:SchemaExtension = new DefaultSchemaExtension(), // Optionally can be included for arbitrary manipulation of generated schemas, off by default
   failOnUnknownProperties:Boolean = true // Must match with the corresponding ObjectMapper setting!
@@ -308,6 +311,10 @@ class JsonSchemaGenerator
   // failing tests. If we ever decide to contribute back to open source, we will need to add the Java API option.
   var globalRefTracker: Map[JavaType, String] = Map[JavaType, String]()
 
+  // Same as property above, but tracks all found models. This way, if we've seen a model before, we don't need to regenerate it, but can still include
+  // it the "definitions" section of a model that has a ref to it.
+  var globalDefinitionsTracker: Map[String, JsonNode] = Map[String, JsonNode]()
+
   val dateFormatMapping = Map[String,String](
     // Java7 dates
     "java.time.LocalDateTime" -> "datetime-local",
@@ -351,7 +358,6 @@ class JsonSchemaGenerator
   // Class that manages creating new definitions or getting $refs to existing definitions
   class DefinitionsHandler(refTracker:Option[Map[JavaType, String]]) {
     private var class2Ref = if (refTracker.isDefined) refTracker.get else Map[JavaType, String]()
-    private var modelsCreated = false
     private val definitionsNode = JsonNodeFactory.instance.objectNode()
 
 
@@ -392,12 +398,18 @@ class JsonSchemaGenerator
 
           workInProgress match {
             case None =>
+              val shortRef = getDefinitionName(clazz)
+              if (config.alwaysReturnDefinitions) {
+                globalDefinitionsTracker.get(shortRef)
+                  .map(definition => definitionsNode.set(shortRef, definition))
+              }
               DefinitionInfo(Some(ref), None)
 
             case Some(w) =>
               // this is a recursive polymorphism call
               if ( clazz.getRawClass != w.classInProgress) throw new Exception(s"Wrong class - working on ${w.classInProgress} - got $clazz")
 
+              definitionsNode.set(ref, w.nodeInProgress)
               DefinitionInfo(None, objectDefinitionBuilder(w.nodeInProgress))
           }
 
@@ -413,12 +425,14 @@ class JsonSchemaGenerator
             longRef = "#/definitions/"+getDefinitionName(clazz) + "_" + retryCount
           }
           class2Ref = class2Ref + (clazz -> longRef)
-          modelsCreated = true
 
           // create definition
           val node = JsonNodeFactory.instance.objectNode()
+          if (config.alwaysReturnDefinitions) {
+            globalDefinitionsTracker = globalDefinitionsTracker + (shortRef -> node)
+          }
 
-          // When processing polymorphism, we might get multiple recursive calls to getOrCreateDefinition - this is a wau to combine them
+          // When processing polymorphism, we might get multiple recursive calls to getOrCreateDefinition - this is a way to combine them
           workInProgress = Some(WorkInProgress(clazz.getRawClass, node))
 
           definitionsNode.set(shortRef, node)
@@ -434,7 +448,7 @@ class JsonSchemaGenerator
     }
 
     def getFinalDefinitionsNode():Option[ObjectNode] = {
-      if (!modelsCreated) None else Some(definitionsNode)
+      if (!definitionsNode.fields().hasNext) None else Some(definitionsNode)
     }
 
     def getFinalClass2Ref():Map[JavaType, String] = {
@@ -1414,6 +1428,7 @@ class JsonSchemaGenerator
   def clearSavedDefinitions(): Unit = {
     // Clear saved definitions
     globalRefTracker = Map[JavaType, String]()
+    globalDefinitionsTracker = Map[String, JsonNode]()
   }
 
   // Another janky workaround for HSMP. The JsonSchemaGenerator recursively resolves all submodels and returns a nested JsonNode. However, this loses all the class/type

--- a/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
+++ b/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
@@ -1,9 +1,9 @@
 package com.kjetland.jackson.jsonSchema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.OffsetDateTime;
 import java.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class UseItFromJavaTest {
 
@@ -40,6 +40,7 @@ public class UseItFromJavaTest {
             new HashSet<>(),
             new HashMap<>(),
             new HashMap<>(),
+            false,
             false);
         JsonSchemaGenerator g2 = new JsonSchemaGenerator(objectMapper, config);
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.38"
+version in ThisBuild := "1.0.39-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.36"
+version in ThisBuild := "1.0.37-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.39"
+version in ThisBuild := "1.0.40-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.38-SNAPSHOT"
+version in ThisBuild := "1.0.38"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.37-SNAPSHOT"
+version in ThisBuild := "1.0.37"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.39-SNAPSHOT"
+version in ThisBuild := "1.0.39"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.36-SNAPSHOT"
+version in ThisBuild := "1.0.36"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.37"
+version in ThisBuild := "1.0.38-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.35-SNAPSHOT"
+version in ThisBuild := "1.0.36-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.35"
+version in ThisBuild := "1.0.35-SNAPSHOT"


### PR DESCRIPTION
### Summary
This pulls in changes that have happened in https://github.com/zrrobbins/mbknor-jackson-jsonSchema since the time #1 was opened. Therefore, this repo will now be equivalent to 1.0.39 of https://github.com/zrrobbins/mbknor-jackson-jsonSchema. 

From this point onward, we should develop on this fork rather than the version under my GH account.  

In addition to pulling the upstream changes, I removed the `travis.yml` file since we're building on Blazar, and bumped the version to `1.1-hubspot-SNAPSHOT`. I'm making a note to write up a guide for the team on how to develop on this repo, which will include how to do version bumps.

cc @jhaber 