### PR TITLE
Mark a model property as not required if it has a JsonInclude annotat…

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1098,8 +1098,8 @@ class JsonSchemaGenerator
                   classOf[com.google.common.base.Optional[_]].isAssignableFrom(propertyType.getRawClass)
 
                 // Check if we should set this property as required. Anything with a @JsonProperty that
-                // has "required" set to true, various javax.validation annotations, or any property
-                // that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
+                // has "required" set to true, various javax.validation annotations, has a JsonInclude annotation other than Include.ALWAYS
+                // or any property that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
                 // annotation can be used to override any of these conditions.
                 val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || (!optionalType && !jsonIncludeOptional))
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -4,7 +4,7 @@ import java.util
 import java.util.function.Supplier
 import java.util.{Optional, List => JList}
 
-import com.fasterxml.jackson.annotation.{JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
 import com.fasterxml.jackson.core.JsonParser.NumberType
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -1088,6 +1088,10 @@ class JsonSchemaGenerator
                   .flatMap(p => Option(p.getAnnotation(classOf[JsonSchemaProperty])))
                   .map(_.required())
 
+                val jsonIncludeOptional:Boolean = prop
+                  .flatMap(p => Option(p.getAnnotation(classOf[JsonInclude])))
+                  .map(!_.value().equals(JsonInclude.Include.ALWAYS)).getOrElse(false)
+
                 // Figure out if the type is considered optional by either Java or Scala.
                 val optionalType:Boolean = classOf[Option[_]].isAssignableFrom(propertyType.getRawClass) ||
                   classOf[Optional[_]].isAssignableFrom(propertyType.getRawClass) ||
@@ -1097,7 +1101,7 @@ class JsonSchemaGenerator
                 // has "required" set to true, various javax.validation annotations, or any property
                 // that is NOT an Optional type is set as required by default. The @JsonSchemaProperty
                 // annotation can be used to override any of these conditions.
-                val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || !optionalType)
+                val requiredProperty:Boolean = jsonSchemaRequired.getOrElse(jsonPropertyRequired || validationAnnotationRequired(prop) || (!optionalType && !jsonIncludeOptional))
 
                 val thisPropertyNode:PropertyNode = {
                   val thisPropertyNode = JsonNodeFactory.instance.objectNode()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1-hubspot-SNAPSHOT"
+version in ThisBuild := "1.2-hubspot-SNAPSHOT"


### PR DESCRIPTION
…ion with any value other than Include.ALWAYS

This PR will update the logic to mark any model properties that are annotated with `@JsonInclude` with any value other than `Include.ALWAYS`.

Feedback welcome.

@zrrobbins @emm035 @elangan @ssethia2 