### PR TITLE
Mark model properties as not required if the method has a Value.Default annotation

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2-hubspot-SNAPSHOT"
+version in ThisBuild := "1.3-hubspot-SNAPSHOT"


### PR DESCRIPTION
Mark a model property as not required if the method has a JsonInclude annotation.

---

@zrrobbins @emm035 @elangan @chrisbaldauf 