### PR TITLE
Support overriding property name with ApiModelProperty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,12 +39,14 @@ lazy val commonSettings = Seq(
 val jacksonVersion = "2.9.8"
 val jacksonModuleScalaVersion = "2.9.8"
 val slf4jVersion = "1.7.26"
+val swaggerApiVersion = "1.5.13"
 
 
 lazy val deps  = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "javax.validation" % "validation-api" % "2.0.1.Final",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
+  "io.swagger" % "swagger-annotations" % swaggerApiVersion,
   "io.github.classgraph" % "classgraph" % "4.8.22",
   "com.google.guava" % "guava" % "25.0-jre", 
   "org.scalatest" %% "scalatest" % "3.0.7" % "test",

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNo
 import com.fasterxml.jackson.databind.util.ClassUtil
 import com.kjetland.jackson.jsonSchema.annotations._
 import io.github.classgraph.{ClassGraph, ScanResult}
+import io.swagger.annotations.ApiModelProperty
 import javax.validation.constraints._
 import org.slf4j.LoggerFactory
 
@@ -1105,7 +1106,14 @@ class JsonSchemaGenerator
 
                 val thisPropertyNode:PropertyNode = {
                   val thisPropertyNode = JsonNodeFactory.instance.objectNode()
-                  propertiesNode.set(propertyName, thisPropertyNode)
+                  val apiModelProperty:Option[ApiModelProperty] = prop.flatMap(p => Option(p.getAnnotation(classOf[ApiModelProperty])))
+
+                  if (apiModelProperty.isDefined && apiModelProperty.exists(!_.name().equals(""))) {
+                    propertiesNode.set(apiModelProperty.get.name(), thisPropertyNode)
+                  } else {
+                    propertiesNode.set(propertyName, thisPropertyNode)
+                  }
+
 
                   if ( config.usePropertyOrdering ) {
                     thisPropertyNode.put("propertyOrder", nextPropertyOrderIndex)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2-hubspot-SNAPSHOT"
+version in ThisBuild := "1.3-hubspot-SNAPSHOT"


### PR DESCRIPTION
Adds support for overriding generated property names using the `ApiModelProperty` annotation. I bumped the version, but wasn't sure if that's the way we prefer to increment.

@zrrobbins 
@elangan 