### PR TITLE
JsonNode fallback type

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -677,6 +677,9 @@ class JsonSchemaGenerator
         log.warn(s"Not able to generate jsonSchema-info for type: ${_type} - probably using custom serializer which does not override acceptJsonFormatVisitor")
       }
 
+      if(_type != null && _type.isTypeOrSubTypeOf(classOf[JsonNode])) {
+        node.put("type", "object")
+      }
 
       new JsonAnyFormatVisitor {
       }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3-hubspot-SNAPSHOT"
+version in ThisBuild := "1.4-hubspot-SNAPSHOT"


### PR DESCRIPTION
When encountering the `JsonNode` type in an array/collection type, the schema generator ended up using the `expectAnyFormat` method, likely due because Jackson searched for a custom serializer but couldn't find one. This adds support for catching `JsonNode` types and then formatting them correctly as a `type: object`.

JsonNode Typed-Collection Before:
```
inputs:
    type: array
    items: {}
```
After:
```
inputs:
    type: array
    items: 
        type: object
```

@emm035 @elangan 