### PR TITLE
Handle Object.class types

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -677,7 +677,7 @@ class JsonSchemaGenerator
         log.warn(s"Not able to generate jsonSchema-info for type: ${_type} - probably using custom serializer which does not override acceptJsonFormatVisitor")
       }
 
-      if(_type != null && _type.isTypeOrSubTypeOf(classOf[JsonNode])) {
+      if(_type != null && (_type.isTypeOrSubTypeOf(classOf[JsonNode]) || _type.getRawClass == classOf[Object])) {
         node.put("type", "object")
       }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4-hubspot-SNAPSHOT"
+version in ThisBuild := "1.5-hubspot-SNAPSHOT"


### PR DESCRIPTION
This is a follow up to https://github.com/HubSpot/mbknor-jackson-jsonSchema/pull/6. It looks like the same behavior is happening for the Java `Object` type, so I've added a check for that as well. This will ensure that array properties with an `Object` items type at least show up in the Swagger structure after ObjectMapper serialization, prior to that they were getting removed.

This will result in the same output change described in https://github.com/HubSpot/mbknor-jackson-jsonSchema/pull/6, but for `Object.class` types as well now too.

@emm035 @elangan