### PR TITLE
Support to string serializer annot

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,8 +10,9 @@ buildpack:
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
   PUBLISH_DIR_WITHOUT_VERSION: '"$PROJECT_NAME"_2.12'
-  SBT_TAR_FILE_NAME: "sbt-1.3.8.tgz"
-  SBT_TAR_LINK: "https://piccolo.link/$SBT_TAR_FILE_NAME"
+  SBT_TAR_VERSION: "1.3.8"
+  SBT_TAR_FILE_NAME: "sbt-$SBT_TAR_VERSION.tgz"
+  SBT_TAR_LINK: "https://github.com/sbt/sbt/releases/download/v$SBT_TAR_VERSION/$SBT_TAR_FILE_NAME"
   SBT_FILE: "/tmp/sbt-install/$SBT_TAR_FILE_NAME"
   HOME_BIN: "$HOME/bin"
   SBT_BIN: "$HOME_BIN/sbt/bin"

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedClass
 import com.fasterxml.jackson.databind.jsonFormatVisitors._
 import com.fasterxml.jackson.databind.jsontype.impl.MinimalClassNameIdResolver
 import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNode}
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.databind.util.ClassUtil
 import com.kjetland.jackson.jsonSchema.annotations._
 import io.github.classgraph.{ClassGraph, ScanResult}

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1183,9 +1183,7 @@ class JsonSchemaGenerator
                   p =>
                     Option(p.getAnnotation(classOf[JsonSerialize])).map {
                       jsonSerialize =>
-                          if(jsonSerialize.using().equals(classOf[ToStringSerializer])) {
-                            ToStringSerializer.instance.acceptJsonFormatVisitor(childVisitor, propertyType)
-                          }
+                        jsonSerialize.using().newInstance.acceptJsonFormatVisitor(childVisitor, propertyType)
                     }
                 }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1463,6 +1463,24 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
     }
 
   }
+
+  test("pojo with ToStringSerializer") {
+
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoWithJsonSerializer)
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoWithJsonSerializer.getClass, Some(jsonNode))
+
+      assert(schema.at("/properties/realLong/type").asText() == "integer")
+
+      assert(schema.at("/properties/realDouble/type").asText() == "number")
+
+      assert(schema.at("/properties/realString/type").asText() == "string")
+
+      assert(schema.at("/properties/longSerializedAsString/type").asText() == "string")
+
+      assert(schema.at("/properties/doubleSerializedAsString/type").asText() == "string")
+    }
+  }
 }
 
 trait TestData {
@@ -1644,5 +1662,7 @@ trait TestData {
   val genericClassVoid = new GenericClassVoid()
 
   val genericMapLike = new GenericMapLike(Collections.singletonMap("foo", "bar"))
+
+  val pojoWithJsonSerializer = new PojoWithJsonSerializer()
 
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1479,6 +1479,11 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
       assert(schema.at("/properties/longSerializedAsString/type").asText() == "string")
 
       assert(schema.at("/properties/doubleSerializedAsString/type").asText() == "string")
+
+      assert(schema.at("/properties/localDate/type").asText() == "string")
+
+      assert(schema.at("/properties/localDate/format").asText() == "date")
+
     }
   }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
@@ -1,5 +1,13 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import com.kjetland.jackson.jsonSchema.testData.utils.LocalDateSerializer;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
@@ -15,6 +23,9 @@ public class PojoWithJsonSerializer {
 
     @JsonSerialize(using = ToStringSerializer.class)
     public double doubleSerializedAsString = 5.5;
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    public LocalDate localDate = LocalDate.of(2000, 1,1 );
 
     @Override
     public boolean equals(Object o) {

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
@@ -1,0 +1,38 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+public class PojoWithJsonSerializer {
+    public long realLong = 4;
+
+    public double realDouble = 4.5;
+
+    public String realString = "str";
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    public long longSerializedAsString = 5;
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    public double doubleSerializedAsString = 5.5;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PojoWithJsonSerializer that = (PojoWithJsonSerializer) o;
+
+        if (realLong != that.realLong) return false;
+        if (longSerializedAsString != that.longSerializedAsString) return false;
+        return realString != null ? realString.equals(that.realString) : that.realString == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (realLong ^ (realLong >>> 32));
+        result = 31 * result + (realString != null ? realString.hashCode() : 0);
+        result = 31 * result + (int) (longSerializedAsString ^ (longSerializedAsString >>> 32));
+        return result;
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithJsonSerializer.java
@@ -1,8 +1,8 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
-import java.io.IOException;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
 import com.kjetland.jackson.jsonSchema.testData.utils.LocalDateSerializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,15 +35,15 @@ public class PojoWithJsonSerializer {
         PojoWithJsonSerializer that = (PojoWithJsonSerializer) o;
 
         if (realLong != that.realLong) return false;
+        if (Double.compare(that.realDouble, realDouble) != 0) return false;
         if (longSerializedAsString != that.longSerializedAsString) return false;
-        return realString != null ? realString.equals(that.realString) : that.realString == null;
+        if (Double.compare(that.doubleSerializedAsString, doubleSerializedAsString) != 0) return false;
+        return Objects.equals(realString, that.realString) && Objects.equals(localDate, that.localDate);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (realLong ^ (realLong >>> 32));
-        result = 31 * result + (realString != null ? realString.hashCode() : 0);
-        result = 31 * result + (int) (longSerializedAsString ^ (longSerializedAsString >>> 32));
+        int result = Objects.hash(realLong, realDouble, longSerializedAsString, doubleSerializedAsString, realString, localDate);
         return result;
     }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/utils/LocalDateSerializer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/utils/LocalDateSerializer.java
@@ -1,0 +1,21 @@
+package com.kjetland.jackson.jsonSchema.testData.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+    @Override
+    public void serialize(
+            LocalDate localDate,
+            JsonGenerator jsonGenerator,
+            SerializerProvider provider
+    ) throws IOException {
+        jsonGenerator.writeString(localDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
+    }
+}
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5-hubspot-SNAPSHOT"
+version in ThisBuild := "1.6-hubspot-SNAPSHOT"


### PR DESCRIPTION
What
Added support for JsonSerializer annotation in JsonSchemaGenerator, when a property is annotated with @JsonSerialize, we parse the serializer in this annotation and call `acceptJsonFormatVisitor` on it, the default behavior of this method is defined in [JsonSerializer](https://github.com/FasterXML/jackson-databind/blob/8c9c75a48bf302e7cf0c8fcd1dbfe2e1d53b5f2c/src/main/java/com/fasterxml/jackson/databind/jsonFormatVisitors/JsonFormatVisitable.java#L10) and can be override by custom serializer.

Test
added PojoWithJsonSerializer which have properties annotated with both ToStringSerializer and a custom serializer LocalDateSerializer, test passed with expected result

Manual Test
Updated the pom dependency in HSMP to `1.0-support-toStringSerializer-annot-SNAPSHOT`
run `maven clean install` in HSMP
run `maven clean compile swagger:preview` locally in cv-public-api, check the generated spec and thread id is marked as string as expected

<img width="643" alt="Screen Shot 2021-09-24 at 1 00 42 PM" src="https://user-images.githubusercontent.com/65409677/134714785-d411f042-e737-4669-bd2b-91af27906cda.png">

@zrrobbins @jhartz 