### PR TITLE
create a config list for supported serializer type

### DIFF
--- a/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
+++ b/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
@@ -40,6 +40,7 @@ public class UseItFromJavaTest {
             new HashSet<>(),
             new HashMap<>(),
             new HashMap<>(),
+            new HashSet<>(),
             false,
             false);
         JsonSchemaGenerator g2 = new JsonSchemaGenerator(objectMapper, config);

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6-hubspot-SNAPSHOT"
+version in ThisBuild := "1.7-hubspot-SNAPSHOT"


### PR DESCRIPTION
The CRM Spec generation was broken when updated to jsonGeneratorSchema 1.6 which I think was caused by the `Iso8601TimeFilterableBuilderShim.java` builder in CollectionResponse which has a createdAt and requestedAt.
It might be a more complex issue to solve, in the mean time, I'm gonna switch to a whitelisted serializer which we are gonna support at the moment.

@zrrobbins 