### PR TITLE
Adding_test_case_removing_compact8_lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ val jacksonVersion = "2.9.8"
 val jacksonModuleScalaVersion = "2.9.8"
 val slf4jVersion = "1.7.26"
 val swaggerApiVersion = "1.5.13"
+val scalaJava8CompatVersion = "1.0.2"
+
 
 
 lazy val deps  = Seq(
@@ -56,7 +58,8 @@ lazy val deps  = Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion % "test",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion % "test",
   "joda-time" % "joda-time" % "2.10.1" % "test",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test"
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
+  "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
 )
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ val jacksonVersion = "2.9.8"
 val jacksonModuleScalaVersion = "2.9.8"
 val slf4jVersion = "1.7.26"
 val swaggerApiVersion = "1.5.13"
-val scalaJava8CompatVersion = "1.0.2"
 
 
 
@@ -58,8 +57,7 @@ lazy val deps  = Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion % "test",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion % "test",
   "joda-time" % "joda-time" % "2.10.1" % "test",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
-  "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test"
 )
 
 lazy val root = (project in file("."))

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -3,7 +3,6 @@ package com.kjetland.jackson.jsonSchema
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 import java.util
 import java.util.{Collections, Optional, TimeZone}
-
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, ObjectNode}
 import com.fasterxml.jackson.databind.{JavaType, JsonNode, ObjectMapper, SerializationFeature}
@@ -24,9 +23,9 @@ import com.kjetland.jackson.jsonSchema.testData.polymorphism5.{Child51, Child52,
 import com.kjetland.jackson.jsonSchema.testDataScala._
 import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
 import org.scalatest.{BeforeAndAfter, FunSuite, Ignore, Matchers}
-import scala.compat.java8.OptionConverters._
 
 import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters.RichOptionForJava8
 
 class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter {
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -2,7 +2,7 @@ package com.kjetland.jackson.jsonSchema
 
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 import java.util
-import java.util.{Collections, Optional, TimeZone}
+import java.util.{Collections, Optional, OptionalDouble, OptionalInt, OptionalLong, TimeZone}
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, ObjectNode}
 import com.fasterxml.jackson.databind.{JavaType, JsonNode, ObjectMapper, SerializationFeature}
@@ -25,7 +25,7 @@ import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
 import org.scalatest.{BeforeAndAfter, FunSuite, Ignore, Matchers}
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters.RichOptionForJava8
+
 
 class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter {
 
@@ -1582,7 +1582,7 @@ trait TestData {
 
   val manyPrimitivesScala = ManyPrimitivesScala("s1", 1, _boolean = true, 0.1)
 
-  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(1).asPrimitive, Some(true), Some(0.1), Some(0.1).asPrimitive, Some(1L).asPrimitive, Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
+  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), OptionalInt.of(1), Some(true), Some(0.1), OptionalDouble.of(0.1), OptionalLong.of(1L), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
 
   val pojoUsingOptionalJava = new PojoUsingOptionalJava(Optional.of("s"), Optional.of(1), Optional.of(5), Optional.of(child1), Optional.of(util.Arrays.asList(classNotExtendingAnything)))
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -24,6 +24,7 @@ import com.kjetland.jackson.jsonSchema.testData.polymorphism5.{Child51, Child52,
 import com.kjetland.jackson.jsonSchema.testDataScala._
 import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
 import org.scalatest.{BeforeAndAfter, FunSuite, Ignore, Matchers}
+import scala.compat.java8.OptionConverters._
 
 import scala.collection.JavaConverters._
 
@@ -1582,7 +1583,7 @@ trait TestData {
 
   val manyPrimitivesScala = ManyPrimitivesScala("s1", 1, _boolean = true, 0.1)
 
-  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(true), Some(0.1), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
+  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(1).asPrimitive, Some(true), Some(0.1), Some(0.1).asPrimitive, Some(1L).asPrimitive, Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
 
   val pojoUsingOptionalJava = new PojoUsingOptionalJava(Optional.of("s"), Optional.of(1), Optional.of(5), Optional.of(child1), Optional.of(util.Arrays.asList(classNotExtendingAnything)))
 


### PR DESCRIPTION
1. Removed unwanted imports
2. Removed compact8 lib since it cannot be supported in 2.10x scala versions.
3. Altered test case for passing OptionalInt, OptionalLong, OptionalDouble as parameters