### PR TITLE
Handle java Object consistently across jackson versions

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -943,7 +943,8 @@ class JsonSchemaGenerator
     override def expectObjectFormat(_type: JavaType) = {
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
       if (_type.hasRawClass(classOf[java.lang.Object])) {
-        return expectAnyFormat(_type)
+        expectAnyFormat(_type)
+        return null
       }
       val subTypes: List[Class[_]] = extractSubTypes(_type)
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -942,7 +942,7 @@ class JsonSchemaGenerator
 
     override def expectObjectFormat(_type: JavaType) = {
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
-      if (_type.hasRawClass(java.lang.Object)) {
+      if (_type.hasRawClass(java.lang.Object.class)) {
         return expectAnyFormat(_type)
       }
       val subTypes: List[Class[_]] = extractSubTypes(_type)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -942,7 +942,7 @@ class JsonSchemaGenerator
 
     override def expectObjectFormat(_type: JavaType) = {
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
-      if (_type.hasRawClass(java.lang.Object.class)) {
+      if (_type.hasRawClass(classOf[java.lang.Object])) {
         return expectAnyFormat(_type)
       }
       val subTypes: List[Class[_]] = extractSubTypes(_type)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -944,7 +944,7 @@ class JsonSchemaGenerator
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
       if (_type.hasRawClass(classOf[java.lang.Object])) {
         expectAnyFormat(_type)
-        return null
+        null
       }
       val subTypes: List[Class[_]] = extractSubTypes(_type)
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -941,7 +941,10 @@ class JsonSchemaGenerator
     }
 
     override def expectObjectFormat(_type: JavaType) = {
-
+      // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
+      if (_type.hasRawClass(java.lang.Object)) {
+        return expectAnyFormat(_type)
+      }
       val subTypes: List[Class[_]] = extractSubTypes(_type)
 
       // Check if we have subtypes

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1582,7 +1582,7 @@ trait TestData {
 
   val manyPrimitivesScala = ManyPrimitivesScala("s1", 1, _boolean = true, 0.1)
 
-  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(true), Some(0.1), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
+  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(2), Some(true), Some(0.1), Some(2.0), Some(2), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
 
   val pojoUsingOptionalJava = new PojoUsingOptionalJava(Optional.of("s"), Optional.of(1), Optional.of(5), Optional.of(child1), Optional.of(util.Arrays.asList(classNotExtendingAnything)))
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -2,7 +2,7 @@ package com.kjetland.jackson.jsonSchema
 
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 import java.util
-import java.util.{Collections, Optional, TimeZone}
+import java.util.{Collections, Optional, TimeZone, OptionalDouble, OptionalInt, OptionalLong}
 
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, ObjectNode}
@@ -1582,7 +1582,7 @@ trait TestData {
 
   val manyPrimitivesScala = ManyPrimitivesScala("s1", 1, _boolean = true, 0.1)
 
-  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), Some(2), Some(true), Some(0.1), Some(2.0), Some(2), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
+  val pojoUsingOptionScala = PojoUsingOptionScala(Some("s1"), Some(1), OptionalInt.of(2), Some(true), Some(0.1), OptionalDouble.of(2.0), OptionalLong.of(2), Some(child1Scala), Some(List(classNotExtendingAnythingScala)))
 
   val pojoUsingOptionalJava = new PojoUsingOptionalJava(Optional.of("s"), Optional.of(1), Optional.of(5), Optional.of(child1), Optional.of(util.Arrays.asList(classNotExtendingAnything)))
 


### PR DESCRIPTION
Starting from Jackson 2.13 the JsonFormatVisitor directs to [expectObjectFormat](https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75) which results in jsonSchema to create a ref to a empty type called "object" but 2.12 directs to [expectAnyFormat](https://github.com/FasterXML/jackson-databind/blob/2.12/src/main/java/com/fasterxml/jackson/databind/ser/impl/UnknownSerializer.java#L66) which is handled effectively as string values by jsonSchema .