### PR TITLE
Dont add additional props for object class

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -793,11 +793,14 @@ class JsonSchemaGenerator
         }
       }
 
-      definitionsHandler.pushWorkInProgress()
+      if (!_type.getContentType.hasRawClass(classOf[java.lang.Object])) {
+        definitionsHandler.pushWorkInProgress()
 
-      val childVisitor = createChild(additionalPropsObject, None)
-      objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.getContentType), childVisitor)
-      definitionsHandler.popworkInProgress()
+        val childVisitor = createChild(additionalPropsObject, None)
+        objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.getContentType), childVisitor)
+
+        definitionsHandler.popworkInProgress()
+      }
 
       if (_type != null) {
         config.schemaExtension.modifyProperty(node, _type.getRawClass, Optional.ofNullable(currentProperty.orNull))


### PR DESCRIPTION
This prevents adding any additional schema properties for object types, this will prevent the object_type from being set to object in a Map<String, Object> field, since the value here could be a string.

This is related to behavior introduced in  https://github.com/HubSpot/mbknor-jackson-jsonSchema/pull/7