### PR TITLE
Fix early return

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -940,7 +940,7 @@ class JsonSchemaGenerator
       merge(thisObjectNode, injectJsonNode)
     }
 
-    override def expectObjectFormat(_type: JavaType) = {
+    override def expectObjectFormat(_type: JavaType): JsonObjectFormatVisitor = {
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
       if (_type.hasRawClass(classOf[java.lang.Object])) {
         expectAnyFormat(_type)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -944,7 +944,7 @@ class JsonSchemaGenerator
       // Fix for jackson 2.13+ https://github.com/FasterXML/jackson-databind/blob/2.17/src/main/java/com/fasterxml/jackson/databind/ser/std/ToEmptyObjectSerializer.java#L75
       if (_type.hasRawClass(classOf[java.lang.Object])) {
         expectAnyFormat(_type)
-        null
+        return null
       }
       val subTypes: List[Class[_]] = extractSubTypes(_type)
 


### PR DESCRIPTION
This is a followup to https://github.com/HubSpot/mbknor-jackson-jsonSchema/pull/18 which actually adds the early return. This code should be dormant and compatible with version of jackson at 2.12 but will activate after its bumped to jackson > 2.13