### PR TITLE
Fix recursive polymorphism definition resolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val deps  = Seq(
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "io.swagger" % "swagger-annotations" % swaggerApiVersion,
   "io.github.classgraph" % "classgraph" % "4.8.22",
-  "com.google.guava" % "guava" % "25.0-jre", 
+  "com.google.guava" % "guava" % "25.0-jre",
   "org.scalatest" %% "scalatest" % "3.0.7" % "test",
   "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
   "com.github.java-json-tools" % "json-schema-validator" % "2.2.10" % "test",

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/RecursiveNestedPolymorphism.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/RecursiveNestedPolymorphism.scala
@@ -1,0 +1,13 @@
+package com.kjetland.jackson.jsonSchema.testDataScala
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(Array(
+  new JsonSubTypes.Type(value = classOf[Column], name = "Column"),
+  new JsonSubTypes.Type(value = classOf[Module], name = "Module")
+))
+trait RowItem
+case class Column(rows:List[Row]) extends RowItem
+case class Module(data:String) extends RowItem
+case class Row(items:List[RowItem])

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/SameNameNested.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/SameNameNested.scala
@@ -1,0 +1,6 @@
+package com.kjetland.jackson.jsonSchema.testDataScala
+
+case class SameNameNestedParent(
+  p1:com.kjetland.jackson.jsonSchema.testDataScala.package1.Column,
+  p2:com.kjetland.jackson.jsonSchema.testDataScala.package2.Column
+)

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/package1/RecursiveNestedPolymorphism.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/package1/RecursiveNestedPolymorphism.scala
@@ -1,0 +1,15 @@
+package com.kjetland.jackson.jsonSchema.testDataScala.package1
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+
+case class Package1Brand(data:String)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(Array(
+  new JsonSubTypes.Type(value = classOf[Column], name = "Column"),
+  new JsonSubTypes.Type(value = classOf[Module], name = "Module")
+))
+trait RowItem
+case class Column(rows:List[Row], brand:Package1Brand) extends RowItem
+case class Module(data:String, brand:Package1Brand) extends RowItem
+case class Row(items:List[RowItem], brand:Package1Brand)

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/package2/RecursiveNestedPolymorphism.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/package2/RecursiveNestedPolymorphism.scala
@@ -1,0 +1,15 @@
+package com.kjetland.jackson.jsonSchema.testDataScala.package2
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+
+case class Package2Brand(data:String)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(Array(
+  new JsonSubTypes.Type(value = classOf[Column], name = "Column"),
+  new JsonSubTypes.Type(value = classOf[Module], name = "Module")
+))
+trait RowItem
+case class Column(rows:List[Row], brand:Package2Brand) extends RowItem
+case class Module(data:String, brand:Package2Brand) extends RowItem
+case class Row(items:List[RowItem], brand:Package2Brand)


### PR DESCRIPTION
This should fix two issues:
1. Because the shortRef was originally generated via `getDefinitionName` but did not consider that classes sharing a simple name can have suffixes in their long and short ref names, the resolution could lead to issues where a definition for a class in one package was being overridden by a definition for a class sharing the same simple name in another package.
2. Definitions were being set with `definitionsNode.set(ref, w.nodeInProgress)` instead of `definitionsNode.set(shortRef, w.nodeInProgress)` for in progress nodes, which would lead to duplicate definitions in the final schema (one with the long ref, one with the short ref). This call also appears to be redundant, since if a definition is in progress, it should always be added to the definitions set, even across runs, but it was left in place, but with a check to alwaysReturnDefinitions, in case I missed something.

Context:
https://github.com/HubSpot/mbknor-jackson-jsonSchema/commit/772dc8b2b1a88ae0aa059074eedffe33ab027760
https://hubspot.slack.com/archives/C08ADS1C887/p1740094210967859
https://hubspot.slack.com/archives/C5QNWTWFJ/p1740139578561809