### PR TITLE
Add support for Jackson's JsonClassDescription annotation

### DIFF
--- a/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaDescription.java
+++ b/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaDescription.java
@@ -7,7 +7,7 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Same as com.fasterxml.jackson.annotation.JsonPropertyDescription
+ * Same as com.fasterxml.jackson.annotation.JsonPropertyDescription or com.fasterxml.jackson.annotation.JsonClassDescription
  */
 @Target({ METHOD, FIELD, PARAMETER, TYPE })
 @Retention(RUNTIME)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -4,7 +4,7 @@ import java.util
 import java.util.function.Supplier
 import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong, List => JList}
 
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonClassDescription, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
 import com.fasterxml.jackson.core.JsonParser.NumberType
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -1002,7 +1002,7 @@ class JsonSchemaGenerator
 
             // If class is annotated with JsonSchemaDescription, we should add it
             Option(ac.getAnnotations.get(classOf[JsonSchemaDescription])).map(_.value())
-              .orElse(Option(ac.getAnnotations.get(classOf[JsonPropertyDescription])).map(_.value))
+              .orElse(Option(ac.getAnnotations.get(classOf[JsonClassDescription])).map(_.value))
               .foreach {
                 description: String =>
                   thisObjectNode.put("description", description)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -4,7 +4,7 @@ import java.util
 import java.util.function.Supplier
 import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong, List => JList}
 
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonClassDescription, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonInclude, JsonPropertyDescription, JsonSubTypes, JsonTypeInfo}
 import com.fasterxml.jackson.core.JsonParser.NumberType
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -1002,7 +1002,7 @@ class JsonSchemaGenerator
 
             // If class is annotated with JsonSchemaDescription, we should add it
             Option(ac.getAnnotations.get(classOf[JsonSchemaDescription])).map(_.value())
-              .orElse(Option(ac.getAnnotations.get(classOf[JsonClassDescription])).map(_.value))
+              .orElse(Option(ac.getAnnotations.get(classOf[JsonPropertyDescription])).map(_.value))
               .foreach {
                 description: String =>
                   thisObjectNode.put("description", description)

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -1002,6 +1002,7 @@ class JsonSchemaGenerator
 
             // If class is annotated with JsonSchemaDescription, we should add it
             Option(ac.getAnnotations.get(classOf[JsonSchemaDescription])).map(_.value())
+              .orElse(Option(ac.getAnnotations.get(classOf[JsonPropertyDescription])).map(_.value))
               .orElse(Option(ac.getAnnotations.get(classOf[JsonClassDescription])).map(_.value))
               .foreach {
                 description: String =>

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -887,6 +887,8 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoUsingMaps)
       val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoUsingMaps.getClass, Some(jsonNode))
 
+      assert(schema.at("/description").asText() == "This is our pojo")
+
       assert(schema.at("/properties/string2Integer/type").asText() == "object")
       assert(schema.at("/properties/string2Integer/additionalProperties/type").asText() == "integer")
 
@@ -902,6 +904,8 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers with BeforeAndAfter
     {
       val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.pojoUsingMaps)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.pojoUsingMaps.getClass, Some(jsonNode))
+
+      assert(schema.at("/description").asText() == "This is our pojo")
 
       assert(schema.at("/properties/string2Integer/type").asText() == "object")
       assert(schema.at("/properties/string2Integer/additionalProperties/type").asText() == "integer")

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingMaps.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingMaps.java
@@ -1,9 +1,11 @@
 package com.kjetland.jackson.jsonSchema.testData;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.kjetland.jackson.jsonSchema.testData.polymorphism1.Parent;
 
 import java.util.Map;
 
+@JsonClassDescription("This is our pojo")
 public class PojoUsingMaps {
 
     public Map<String, Integer> string2Integer;


### PR DESCRIPTION
Currently this library only supports Jackson's `JsonPropertyDescription` (which is not allowed on classes) and this library's custom `JsonSchemaDescription` (which is allowed on classes, but is non-standard and requires users to include a direct dependency on this library).

This PR adds support for Jackson's `JsonClassDescription`.

I think [when this feature was added](https://github.com/HubSpot/mbknor-jackson-jsonSchema/commit/96b464b74aad7b1bcc888d264b17e568dfe7242e), [JsonClassDescription was still pretty new](https://github.com/FasterXML/jackson-annotations/issues/73).

As an aside, it looks like jackson-module-jsonSchema [doesn't support JsonClassDescription yet](https://github.com/FasterXML/jackson-module-jsonSchema/issues/88), either.