### PR TITLE
bump scala version to 2.13

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,7 +6,7 @@ buildResources:
 
 env:
   PROJECT_NAME: "mbknor-jackson-jsonschema"
-  PUBLISH_DIR_WITHOUT_VERSION: "${PROJECT_NAME}_2.12"
+  PUBLISH_DIR_WITHOUT_VERSION: "${PROJECT_NAME}_2.13"
   SBT_TAR_VERSION: "1.3.8"
   SBT_TAR_FILE_NAME: "sbt-$SBT_TAR_VERSION.tgz"
   SBT_TAR_LINK: "https://github.com/sbt/sbt/releases/download/v$SBT_TAR_VERSION/$SBT_TAR_FILE_NAME"
@@ -44,11 +44,11 @@ before:
       - write-build-env-var PROJECT_VERSION $($SBT_BIN/sbt -warn 'print version')
       - write-build-env-var PUBLISH_DIR "$PUBLISH_DIR_WITHOUT_VERSION-$(echo $PROJECT_VERSION | sed -n 's/^\([[:digit:]]*\.[[:digit:]]*\)-.*$/\1/p')"
       - mkdir $PUBLISH_DIR
-      - find target/scala-2.12 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
-      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.12-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
+      - find target/scala-2.13 -maxdepth 1 -type f | xargs -I {} cp {} $PUBLISH_DIR
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.13-"$PROJECT_VERSION".pom $PUBLISH_DIR/pom.xml
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.13-"$PROJECT_VERSION".jar $PUBLISH_DIR/main.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.13-"$PROJECT_VERSION"-sources.jar $PUBLISH_DIR/sources.jar
+      - mv $PUBLISH_DIR/"$PROJECT_NAME"_2.13-"$PROJECT_VERSION"-javadoc.jar $PUBLISH_DIR/javadoc.jar
 
   - name: uploadAndNotify
     description: "Notifying deploy service"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val commonSettings = Seq(
   organization := "com.kjetland",
   organizationName := "mbknor",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.13.16",
   crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.16"),
   publishMavenStyle := true,
   publishArtifact in Test := false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.8-hubspot-SNAPSHOT"
+version in ThisBuild := "1.9-hubspot-SNAPSHOT"


### PR DESCRIPTION
We need to build mbknor with scala 2.13 for spark 4 (and scala 2.13) migration and bumping up the version so that we can migrate to this with spark 4 while not affecting the current dependencies during rollout