### PR TITLE
Fix ClassCastException with ObjectNode.set() on Jackson 2.21

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -413,7 +413,7 @@ class JsonSchemaGenerator
               val shortRef = getDefinitionName(clazz)
               if (config.alwaysReturnDefinitions) {
                 globalDefinitionsTracker.get(shortRef)
-                  .map(definition => definitionsNode.set(shortRef, definition))
+                  .foreach(definition => definitionsNode.set(shortRef, definition))
               }
               DefinitionInfo(Some(ref), None)
 


### PR DESCRIPTION
Why

Jackson 2.21 changed ObjectNode.set(String, JsonNode) to use a generic return type <T extends JsonNode> T set(...). When this method is called inside Scala's Option.map(), the type inferencer has no context to constrain T and infers Nothing (Scala's bottom type). At runtime, the JVM generates a checkcast to Nothing$ which fails because Jackson actually returns an ObjectNode:

```
  java.lang.ClassCastException: class com.fasterxml.jackson.databind.node.ObjectNode
    cannot be cast to class scala.runtime.Nothing$
    at JsonSchemaGenerator$DefinitionsHandler.$anonfun$getOrCreateDefinition$1(JsonSchemaGenerator.scala:416)
```

In Jackson 2.18, the `ObjectNode` override had the concrete return type ObjectNode (covariant), giving Scala enough type information. The 2.21 version reverted to the generic signature, breaking inference.

What

Changed `.map()` to `.foreach()` on the `Option` at the call site. Since the return value of `set()` is never used — only the side effect of writing to definitionsNode matters — foreach is the correct combinator here and avoids the type inference issue entirely.