### PR TITLE
Fix ClassCastException with ObjectNode.set() on Jackson 2.21

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -413,7 +413,7 @@ class JsonSchemaGenerator
               val shortRef = getDefinitionName(clazz)
               if (config.alwaysReturnDefinitions) {
                 globalDefinitionsTracker.get(shortRef)
-                  .map(definition => definitionsNode.set(shortRef, definition))
+                  .foreach(definition => definitionsNode.set[ObjectNode](shortRef, definition))
               }
               DefinitionInfo(Some(ref), None)
 


### PR DESCRIPTION
  Why

  After upgrading Jackson from 2.18 to 2.21, the library throws at runtime:
```
  java.lang.ClassCastException: class com.fasterxml.jackson.databind.node.ObjectNode
    cannot be cast to class scala.runtime.Nothing$
    at JsonSchemaGenerator$DefinitionsHandler.$anonfun$getOrCreateDefinition$1(JsonSchemaGenerator.scala:416)
```

  In Jackson 2.21, ObjectNode.set(String, JsonNode) uses the generic signature <T extends JsonNode> T set(...). When this method is called inside a Scala lambda (here, Option.foreach), the Scala type inferencer
  has no context to constrain T and infers Nothing (the bottom type). The JVM then emits a checkcast scala/runtime/Nothing$ instruction which fails at runtime because Jackson actually returns an ObjectNode.

  In Jackson 2.18, the ObjectNode override had a covariant concrete return type (ObjectNode), which gave Scala enough information. The 2.21 version reverted to the fully generic signature, breaking inference.

  What

  Added an explicit type argument set[ObjectNode](...) to force T = ObjectNode. The emitted checkcast ObjectNode succeeds at runtime.